### PR TITLE
Add MATLAB utilities and synthetic track fixture tests

### DIFF
--- a/src/util/merge_intervals.m
+++ b/src/util/merge_intervals.m
@@ -1,0 +1,47 @@
+function out = merge_intervals(intervals, varargin)
+% intervals: [N×2] on/off in seconds, on<=off
+% options: 'GapMerge', default 0 (merge gaps <= GapMerge)
+% returns non-overlapping, sorted intervals [M×2]
+%% validate inputs
+if nargin < 1
+    error('merge_intervals:MissingInput', 'The intervals input is required.');
+end
+validateattributes(intervals, {'numeric'}, {'2d', 'ncols', 2}, mfilename, 'intervals');
+if any(isnan(intervals(:))) || any(~isfinite(intervals(:)))
+    error('merge_intervals:InvalidIntervals', 'Intervals must be finite values.');
+end
+if any(intervals(:, 2) < intervals(:, 1))
+    error('merge_intervals:InvalidOrder', 'Each interval must satisfy on <= off.');
+end
+
+parser = inputParser;
+parser.FunctionName = mfilename;
+parser.addParameter('GapMerge', 0, @(x) validateattributes(x, {'numeric'}, {'scalar', '>=', 0}, mfilename, 'GapMerge'));
+parser.parse(varargin{:});
+gap_merge = double(parser.Results.GapMerge);
+
+%% handle empty input
+if isempty(intervals)
+    out = zeros(0, 2);
+    return;
+end
+
+%% sort intervals
+intervals = sortrows(double(intervals), 1);
+
+%% merge logic
+merged = intervals(1, :);
+for idx = 2:size(intervals, 1)
+    current = intervals(idx, :);
+    last = merged(end, :);
+
+    if current(1) <= last(2) + gap_merge
+        merged(end, 2) = max(last(2), current(2));
+    else
+        merged = [merged; current]; %#ok<AGROW>
+    end
+end
+
+%% output
+out = merged;
+end

--- a/src/util/timevec.m
+++ b/src/util/timevec.m
@@ -1,0 +1,12 @@
+function t = timevec(nSamples, fs)
+% return column vector [nSamples×1] of times (s) from 0 to (nSamples-1)/fs
+% validate inputs; error if fs<=0 or nSamples<1
+%% validate inputs
+validateattributes(nSamples, {'numeric'}, {'scalar', 'integer', '>=', 1}, mfilename, 'nSamples');
+validateattributes(fs, {'numeric'}, {'scalar', 'positive'}, mfilename, 'fs');
+
+%% compute vector
+nSamples = double(nSamples);
+fs = double(fs);
+t = (0:nSamples-1).' ./ fs;
+end

--- a/tests/fixtures/make_synth_colony_track.m
+++ b/tests/fixtures/make_synth_colony_track.m
@@ -1,0 +1,47 @@
+function [x, fs, self_labels, heard_truth] = make_synth_colony_track()
+%% parameters
+fs = 24000;
+duration_s = 30;
+n_samples = round(fs * duration_s);
+
+%% noise bed
+white = randn(n_samples, 1);
+pinkish = filter(1, [1 -0.99], white);
+pinkish = pinkish / max(abs(pinkish));
+x = 0.2 * pinkish;
+
+%% event definitions
+self_freq = 4000;
+heard_freq = 7000;
+self_starts = [5.0; 18.0];
+self_durations = [0.4; 0.5];
+heard_starts = [8.0; 12.5; 24.0];
+heard_durations = [0.3; 0.4; 0.5];
+self_labels = [self_starts, self_starts + self_durations];
+heard_truth = [heard_starts, heard_starts + heard_durations];
+
+%% synthesis
+sample_times = (0:n_samples-1).' / fs;
+for idx = 1:size(self_labels, 1)
+    on = self_labels(idx, 1);
+    off = self_labels(idx, 2);
+    tone_idx = time_indices(on, off, fs, n_samples);
+    tone_t = sample_times(tone_idx) - on;
+    x(tone_idx) = x(tone_idx) + 0.3 * sin(2 * pi * self_freq * tone_t);
+end
+
+for idx = 1:size(heard_truth, 1)
+    on = heard_truth(idx, 1);
+    off = heard_truth(idx, 2);
+    tone_idx = time_indices(on, off, fs, n_samples);
+    tone_t = sample_times(tone_idx) - on;
+    x(tone_idx) = x(tone_idx) + 0.25 * sin(2 * pi * heard_freq * tone_t);
+end
+
+%% helpers
+    function idx = time_indices(onset, offset, rate, total_samples)
+        start_sample = max(1, floor(onset * rate) + 1);
+        end_sample = min(total_samples, ceil(offset * rate));
+        idx = (start_sample:end_sample).';
+    end
+end

--- a/tests/util/test_synth_fixture.m
+++ b/tests/util/test_synth_fixture.m
@@ -1,0 +1,34 @@
+classdef test_synth_fixture < matlab.unittest.TestCase
+    %% setup paths
+    methods (TestClassSetup)
+        function add_fixture_to_path(tc)
+            root_dir = fileparts(fileparts(fileparts(mfilename('fullpath'))));
+            addpath(fullfile(root_dir, 'tests', 'fixtures'));
+        end
+    end
+
+    %% tests
+    methods (Test)
+        function fixture_properties(tc)
+            [x, fs, self_labels, heard_truth] = make_synth_colony_track();
+
+            tc.verifyEqual(size(x, 2), 1);
+            tc.verifyEqual(fs, 24000);
+
+            duration = numel(x) / fs;
+            tc.verifyLessThanOrEqual(abs(duration - 30), 0.1);
+
+            tc.verifyEqual(size(self_labels, 1), 2);
+            tc.verifyEqual(size(heard_truth, 1), 3);
+
+            self_durations = self_labels(:, 2) - self_labels(:, 1);
+            heard_durations = heard_truth(:, 2) - heard_truth(:, 1);
+
+            tc.verifyGreaterThanOrEqual(min(self_durations), 0.2);
+            tc.verifyLessThanOrEqual(max(self_durations), 0.6);
+
+            tc.verifyGreaterThanOrEqual(min(heard_durations), 0.2);
+            tc.verifyLessThanOrEqual(max(heard_durations), 0.6);
+        end
+    end
+end

--- a/tests/util/test_util_basics.m
+++ b/tests/util/test_util_basics.m
@@ -1,0 +1,51 @@
+classdef test_util_basics < matlab.unittest.TestCase
+    %% setup paths
+    methods (TestClassSetup)
+        function add_source_to_path(tc)
+            root_dir = fileparts(fileparts(fileparts(mfilename('fullpath'))));
+            addpath(fullfile(root_dir, 'src', 'util'));
+        end
+    end
+
+    %% tests
+    methods (Test)
+        function timevec_basic(tc)
+            fs = 1000;
+            n = 5;
+            expected = (0:n-1).' / fs;
+            actual = timevec(n, fs);
+            tc.verifyEqual(actual, expected, 'AbsTol', 1e-12);
+        end
+
+        function merge_intervals_cases(tc)
+            intervals = [
+                0.5 1.5;
+                0.0 1.0;
+                2.0 4.0;
+                2.5 3.0;
+                5.0 5.2;
+                5.25 5.4;
+                6.0 6.1
+            ];
+
+            merged = merge_intervals(intervals);
+            expected_default = [
+                0.0 1.5;
+                2.0 4.0;
+                5.0 5.2;
+                5.25 5.4;
+                6.0 6.1
+            ];
+            tc.verifyEqual(merged, expected_default);
+
+            merged_gap = merge_intervals(intervals, 'GapMerge', 0.1);
+            expected_gap = [
+                0.0 1.5;
+                2.0 4.0;
+                5.0 5.4;
+                6.0 6.1
+            ];
+            tc.verifyEqual(merged_gap, expected_gap);
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- add matlab.unittest suites for utility helpers and synthetic audio fixture
- implement time vector helper and interval merging logic under src/util
- build colony track synthesizer fixture used by new tests

## Testing
- matlab -batch "addpath('tests/util'); results = runtests; disp(table(results)); assert(all([results.Passed]));" *(fails: matlab command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd81e0f680832bbe8f6eead4314b96