### PR TITLE
Add IO layer for audio and labels

### DIFF
--- a/src/io/read_audacity_labels.m
+++ b/src/io/read_audacity_labels.m
@@ -1,0 +1,57 @@
+function T = read_audacity_labels(path)
+    % read audacity label rows from a tab-separated file.
+
+    if ~(ischar(path) || (isstring(path) && isscalar(path)))
+        error('read_audacity_labels:InvalidPath', ...
+            'path must be a character vector or scalar string.');
+    end
+
+    if isstring(path)
+        path = char(path);
+    end
+
+    if exist(path, 'file') ~= 2
+        error('read_audacity_labels:MissingFile', 'file not found: %s', path);
+    end
+
+    fid = fopen(path, 'r');
+    if fid < 0
+        error('read_audacity_labels:OpenFailed', 'unable to open file: %s', path);
+    end
+
+    cleaner = onCleanup(@() fclose(fid));
+    raw = textscan(fid, '%f%f%s', 'Delimiter', '\t', 'Whitespace', '', ...
+        'ReturnOnError', false, 'CollectOutput', false);
+
+    onset = raw{1};
+    offset = raw{2};
+    label = raw{3};
+
+    if isempty(onset)
+        onset = zeros(0, 1);
+        offset = zeros(0, 1);
+        label = cell(0, 1);
+    end
+
+    if numel(onset) ~= numel(offset) || numel(onset) ~= numel(label)
+        error('read_audacity_labels:ColumnMismatch', ...
+            'file must contain exactly three columns.');
+    end
+
+    onset = double(onset(:));
+    offset = double(offset(:));
+    label = string(label(:));
+
+    if any(~isfinite(onset)) || any(~isfinite(offset))
+        error('read_audacity_labels:NonFiniteTime', ...
+            'onset and offset values must be finite.');
+    end
+
+    if any(onset < 0) || any(offset < 0) || any(onset > offset)
+        error('read_audacity_labels:InvalidIntervals', ...
+            'onset must be nonnegative and no greater than offset.');
+    end
+
+    % package validated vectors into a typed table.
+    T = table(onset, offset, label, 'VariableNames', {'onset', 'offset', 'label'});
+end

--- a/src/io/read_audio.m
+++ b/src/io/read_audio.m
@@ -1,0 +1,57 @@
+function [x, fs] = read_audio(input)
+    % read audio from a file path or struct and ensure column output.
+
+    if isstruct(input)
+        if ~isfield(input, 'x') || ~isfield(input, 'fs')
+            error('read_audio:MissingFields', ...
+                'struct input must contain fields "x" and "fs".');
+        end
+
+        x = input.x;
+        fs = input.fs;
+    elseif ischar(input) || (isstring(input) && isscalar(input))
+        if isstring(input)
+            input = char(input);
+        end
+
+        if exist(input, 'file') ~= 2
+            error('read_audio:MissingFile', 'file not found: %s', input);
+        end
+
+        [x, fs] = audioread(input);
+    else
+        error('read_audio:InvalidInput', ...
+            'input must be a file path or struct with fields x and fs.');
+    end
+
+    if ~isnumeric(x)
+        error('read_audio:InvalidSamples', 'audio samples must be numeric.');
+    end
+
+    if ~isnumeric(fs) || ~isscalar(fs) || ~isfinite(fs) || fs <= 0
+        error('read_audio:InvalidRate', 'sampling rate must be a positive finite scalar.');
+    end
+
+    x = double(x);
+    fs = double(fs);
+
+    if isempty(x)
+        x = zeros(0, 1);
+    else
+        if ndims(x) > 2
+            error('read_audio:InvalidShape', 'audio array must be one- or two-dimensional.');
+        end
+
+        if isvector(x)
+            x = x(:);
+        else
+            % average multiple channels into a single mono track.
+            x = mean(x, 2);
+            x = x(:);
+        end
+    end
+
+    if any(~isfinite(x))
+        error('read_audio:NonFiniteSamples', 'audio samples must be finite.');
+    end
+end

--- a/src/label/write_audacity_labels.m
+++ b/src/label/write_audacity_labels.m
@@ -1,0 +1,59 @@
+function write_audacity_labels(path, intervals, labels)
+    % write audacity label rows with fixed precision.
+
+    if ~(ischar(path) || (isstring(path) && isscalar(path)))
+        error('write_audacity_labels:InvalidPath', ...
+            'path must be a character vector or scalar string.');
+    end
+
+    if isstring(path)
+        path = char(path);
+    end
+
+    if ~isnumeric(intervals) || ndims(intervals) ~= 2 || size(intervals, 2) ~= 2
+        error('write_audacity_labels:InvalidIntervals', ...
+            'intervals must be an N-by-2 numeric array.');
+    end
+
+    intervals = double(intervals);
+    n = size(intervals, 1);
+
+    if isstring(labels)
+        labels = labels(:);
+    elseif iscell(labels)
+        labels = string(labels(:));
+    elseif ischar(labels)
+        labels = string(cellstr(labels));
+    else
+        error('write_audacity_labels:InvalidLabels', ...
+            'labels must be a string array or cell array of character vectors.');
+    end
+
+    if numel(labels) ~= n
+        error('write_audacity_labels:LengthMismatch', ...
+            'interval count and label count must match.');
+    end
+
+    labels = labels(:);
+
+    if any(~isfinite(intervals(:)))
+        error('write_audacity_labels:NonFiniteTime', ...
+            'intervals must contain finite values.');
+    end
+
+    if any(intervals(:, 1) < 0) || any(intervals(:, 2) < 0) || any(intervals(:, 1) > intervals(:, 2))
+        error('write_audacity_labels:InvalidOrder', ...
+            'intervals must be nonnegative with onset <= offset.');
+    end
+
+    % stream formatted rows to disk.
+    fid = fopen(path, 'w');
+    if fid < 0
+        error('write_audacity_labels:OpenFailed', 'unable to open file: %s', path);
+    end
+
+    cleaner = onCleanup(@() fclose(fid));
+    for i = 1:n
+        fprintf(fid, '%.6f\t%.6f\t%s\n', intervals(i, 1), intervals(i, 2), char(labels(i)));
+    end
+end

--- a/tests/io/test_io_labels_audio.m
+++ b/tests/io/test_io_labels_audio.m
@@ -1,0 +1,65 @@
+classdef test_io_labels_audio < matlab.unittest.TestCase
+    methods (TestClassSetup)
+        function add_source_to_path(tc)
+            root_dir = fileparts(fileparts(fileparts(mfilename('fullpath'))));
+            addpath(fullfile(root_dir, 'src', 'io'));
+            addpath(fullfile(root_dir, 'src', 'label'));
+        end
+    end
+
+    methods (Test)
+        function label_roundtrip(tc)
+            intervals = [
+                0.125 0.500;
+                1.000 1.750;
+                2.250 3.000
+            ];
+            labels = [
+                "CALL";
+                "HEARD";
+                "SILENCE"
+            ];
+
+            label_path = [tempname '.txt'];
+            cleaner = onCleanup(@() test_io_labels_audio.delete_if_exists(label_path));
+            write_audacity_labels(label_path, intervals, labels);
+            actual = read_audacity_labels(label_path);
+
+            tc.verifyEqual(actual.onset, intervals(:, 1), 'AbsTol', 1e-6);
+            tc.verifyEqual(actual.offset, intervals(:, 2), 'AbsTol', 1e-6);
+            tc.verifyEqual(actual.label, labels);
+            clear cleaner;
+        end
+
+        function read_audio_variants(tc)
+            struct_input.x = sin(2 * pi * (0:9) / 10);
+            struct_input.fs = 16000;
+
+            [x_struct, fs_struct] = read_audio(struct_input);
+            tc.verifyEqual(fs_struct, struct_input.fs);
+            tc.verifySize(x_struct, [numel(struct_input.x) 1]);
+            tc.verifyEqual(x_struct, struct_input.x(:), 'AbsTol', 1e-12);
+
+            fs = 8000;
+            t = (0:fs-1).' / fs;
+            audio = 0.5 * sin(2 * pi * 440 * t);
+            audio_path = [tempname '.wav'];
+            cleaner = onCleanup(@() test_io_labels_audio.delete_if_exists(audio_path));
+            audiowrite(audio_path, audio, fs);
+
+            [x_file, fs_file] = read_audio(audio_path);
+            tc.verifyEqual(fs_file, fs);
+            tc.verifySize(x_file, [numel(audio) 1]);
+            tc.verifyEqual(x_file, audio, 'AbsTol', 1e-12);
+            clear cleaner;
+        end
+    end
+
+    methods (Static, Access = private)
+        function delete_if_exists(path)
+            if exist(path, 'file') == 2
+                delete(path);
+            end
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- add an io helper to parse audacity label tracks with validation
- add a writer that emits fixed-precision audacity label files
- add audio reader utility and tests covering label round-trips and audio inputs

## Testing
- not run (octave/matlab not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd84cd52e0832b8a03bcae8f3b434a