### PR TITLE
Add IO utilities for audio and Audacity labels

### DIFF
--- a/src/io/read_audacity_labels.m
+++ b/src/io/read_audacity_labels.m
@@ -1,0 +1,61 @@
+function T = read_audacity_labels(path)
+% read tab-separated audacity labels into a table.
+%% validate input path
+if nargin < 1
+    error('read_audacity_labels:MissingInput', 'The path input is required.');
+end
+if ~(ischar(path) || (isstring(path) && isscalar(path)))
+    error('read_audacity_labels:InvalidPath', 'Path must be a character vector or string scalar.');
+end
+path = char(path);
+if exist(path, 'file') ~= 2
+    error('read_audacity_labels:FileNotFound', 'File not found: %s', path);
+end
+
+%% open file and parse contents
+fid = fopen(path, 'r');
+if fid == -1
+    error('read_audacity_labels:FileOpenFailed', 'Could not open file: %s', path);
+end
+cleaner = onCleanup(@() fclose(fid));
+data = textscan(fid, '%f%f%[^\n\r]', 'Delimiter', '\t', ...
+    'MultipleDelimsAsOne', false, 'ReturnOnError', false);
+
+%% handle empty file
+onset = data{1};
+offset = data{2};
+raw_labels = data{3};
+if isempty(onset)
+    T = table('Size', [0 3], 'VariableTypes', {'double', 'double', 'string'}, ...
+        'VariableNames', {'onset', 'offset', 'label'});
+    return;
+end
+if numel(offset) ~= numel(onset) || numel(raw_labels) ~= numel(onset)
+    error('read_audacity_labels:InvalidFormat', 'Each row must contain onset, offset, and label.');
+end
+
+%% convert data types
+onset = double(onset(:));
+offset = double(offset(:));
+labels = string(raw_labels(:));
+
+%% validate values
+if any(~isfinite(onset)) || any(~isfinite(offset))
+    error('read_audacity_labels:InvalidNumeric', 'Onset and offset must be finite numeric values.');
+end
+if any(isnan(onset)) || any(isnan(offset))
+    error('read_audacity_labels:InvalidNumeric', 'Onset and offset must be numeric.');
+end
+if any(onset < 0) || any(offset < 0)
+    error('read_audacity_labels:NegativeTime', 'Onset and offset must be nonnegative.');
+end
+if any(onset > offset)
+    error('read_audacity_labels:InvalidOrder', 'Each row must satisfy onset <= offset.');
+end
+if numel(onset) > 1 && any(diff(onset) < 0)
+    error('read_audacity_labels:NonMonotonic', 'Onset times must be nondecreasing.');
+end
+
+%% assemble table
+T = table(onset, offset, labels, 'VariableNames', {'onset', 'offset', 'label'});
+end

--- a/src/io/read_audio.m
+++ b/src/io/read_audio.m
@@ -1,0 +1,37 @@
+function [x, fs] = read_audio(input)
+% read audio from struct or wav path and return column vector data.
+%% handle path input
+if ischar(input) || (isstring(input) && isscalar(input))
+    path = char(input);
+    if exist(path, 'file') ~= 2
+        error('read_audio:FileNotFound', 'Audio file not found: %s', path);
+    end
+    [~, ~, ext] = fileparts(path);
+    if ~strcmpi(ext, '.wav')
+        error('read_audio:UnsupportedFormat', 'Only .wav files are supported.');
+    end
+    [raw, fs] = audioread(path);
+    if isempty(raw)
+        error('read_audio:EmptyAudio', 'Audio file contains no samples.');
+    end
+    if size(raw, 2) > 1
+        raw = mean(raw, 2);
+    end
+    x = double(raw(:));
+    fs = double(fs);
+    validateattributes(fs, {'numeric'}, {'scalar', 'positive'}, mfilename, 'fs');
+    return;
+end
+
+%% handle struct input
+if ~isstruct(input)
+    error('read_audio:InvalidInput', 'Input must be a wav path or struct with fields x and fs.');
+end
+if ~isfield(input, 'x') || ~isfield(input, 'fs')
+    error('read_audio:MissingFields', 'Struct input must contain fields x and fs.');
+end
+validateattributes(input.fs, {'numeric'}, {'scalar', 'positive'}, mfilename, 'fs');
+validateattributes(input.x, {'numeric'}, {'vector', 'nonempty'}, mfilename, 'x');
+fs = double(input.fs);
+x = double(input.x(:));
+end

--- a/src/label/write_audacity_labels.m
+++ b/src/label/write_audacity_labels.m
@@ -1,0 +1,55 @@
+function write_audacity_labels(path, intervals, labels)
+% write audacity label track with 6 decimal places.
+%% validate inputs
+if nargin < 3
+    error('write_audacity_labels:MissingInput', 'All inputs are required.');
+end
+if ~(ischar(path) || (isstring(path) && isscalar(path)))
+    error('write_audacity_labels:InvalidPath', 'Path must be a character vector or string scalar.');
+end
+validateattributes(intervals, {'numeric'}, {'2d', 'ncols', 2}, mfilename, 'intervals');
+if ~(isstring(labels) || iscellstr(labels) || (iscell(labels) && all(cellfun(@ischar, labels))))
+    error('write_audacity_labels:InvalidLabels', 'Labels must be a string array or cell array of character vectors.');
+end
+
+%% normalize inputs
+path = char(path);
+intervals = double(intervals);
+if iscell(labels)
+    labels = string(labels);
+else
+    labels = string(labels);
+end
+labels = labels(:);
+if size(intervals, 1) ~= numel(labels)
+    error('write_audacity_labels:SizeMismatch', 'Intervals and labels must have the same number of rows.');
+end
+
+%% validate values
+if any(~isfinite(intervals(:)))
+    error('write_audacity_labels:InvalidIntervals', 'Intervals must contain finite numeric values.');
+end
+if any(intervals(:, 1) < 0) || any(intervals(:, 2) < 0)
+    error('write_audacity_labels:NegativeTime', 'Onset and offset must be nonnegative.');
+end
+if any(intervals(:, 1) > intervals(:, 2))
+    error('write_audacity_labels:InvalidOrder', 'Each interval must satisfy onset <= offset.');
+end
+if size(intervals, 1) > 1 && any(diff(intervals(:, 1)) < 0)
+    error('write_audacity_labels:NonMonotonic', 'Onset times must be nondecreasing.');
+end
+
+%% write file
+fid = fopen(path, 'w');
+if fid == -1
+    error('write_audacity_labels:FileOpenFailed', 'Could not open file for writing: %s', path);
+end
+cleaner = onCleanup(@() fclose(fid));
+for idx = 1:size(intervals, 1)
+    label = labels(idx);
+    if ismissing(label)
+        label = "";
+    end
+    fprintf(fid, '%.6f\t%.6f\t%s\n', intervals(idx, 1), intervals(idx, 2), char(label));
+end
+end

--- a/tests/io/test_io_labels_audio.m
+++ b/tests/io/test_io_labels_audio.m
@@ -1,0 +1,81 @@
+classdef test_io_labels_audio < matlab.unittest.TestCase
+    %% setup paths
+    methods (TestClassSetup)
+        function add_source_to_path(tc) %#ok<INUSD>
+            root_dir = fileparts(fileparts(fileparts(mfilename('fullpath'))));
+            addpath(fullfile(root_dir, 'src', 'io'));
+            addpath(fullfile(root_dir, 'src', 'label'));
+        end
+    end
+
+    %% tests
+    methods (Test)
+        function labels_round_trip(tc)
+            intervals = [
+                0.123456 0.654321;
+                1.234567 2.345678;
+                3.456789 4.567890
+            ];
+            labels = [
+                "call one";
+                "call two";
+                "call three"
+            ];
+            label_path = [tempname(), '.txt'];
+            cleanup_obj = onCleanup(@() delete_if_exists(label_path)); %#ok<NASGU>
+
+            write_audacity_labels(label_path, intervals, labels);
+            tbl = read_audacity_labels(label_path);
+
+            tc.verifyEqual(tbl.onset, intervals(:, 1), 'AbsTol', 1e-6);
+            tc.verifyEqual(tbl.offset, intervals(:, 2), 'AbsTol', 1e-6);
+            tc.verifyEqual(tbl.label, labels);
+            tc.verifyClass(tbl.label, 'string');
+
+            labels_cell = {
+                'call one';
+                'call two';
+                'call three'
+            };
+            write_audacity_labels(label_path, intervals, labels_cell);
+            tbl_cell = read_audacity_labels(label_path);
+
+            tc.verifyEqual(tbl_cell.onset, intervals(:, 1), 'AbsTol', 1e-6);
+            tc.verifyEqual(tbl_cell.offset, intervals(:, 2), 'AbsTol', 1e-6);
+            tc.verifyEqual(tbl_cell.label, string(labels_cell));
+        end
+
+        function read_audio_struct_and_wav(tc)
+            fs = 8000;
+            t = (0:fs-1).' / fs;
+            waveform = sin(2 * pi * 440 * t);
+
+            audio_struct.x = waveform.';
+            audio_struct.fs = fs;
+
+            [x_struct, fs_struct] = read_audio(audio_struct);
+            tc.verifyEqual(fs_struct, fs);
+            tc.verifySize(x_struct, size(waveform));
+            tc.verifyEqual(x_struct, waveform, 'AbsTol', 1e-12);
+
+            wav_path = [tempname(), '.wav'];
+            cleanup_wav = onCleanup(@() delete_if_exists(wav_path)); %#ok<NASGU>
+            audiowrite(wav_path, waveform, fs, 'BitsPerSample', 32);
+
+            [x_file, fs_file] = read_audio(wav_path);
+            tc.verifyEqual(fs_file, fs);
+            tc.verifySize(x_file, size(waveform));
+            tc.verifyEqual(x_file, waveform, 'AbsTol', 1e-6);
+        end
+    end
+end
+
+function delete_if_exists(path)
+if ~(ischar(path) || (isstring(path) && isscalar(path)))
+    return;
+end
+path = char(path);
+if exist(path, 'file') == 2
+    delete(path);
+end
+end


### PR DESCRIPTION
## Summary
- add IO helpers for reading Audacity label tracks and audio waveforms
- write Audacity label files with validation and fixed six-decimal formatting
- cover the new IO layer with round-trip and audio loading unit tests

## Testing
- matlab -batch "results = runtests('tests'); assertSuccess(results);" *(fails: MATLAB not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd882aa8ac832b8a52e106d2297b08