### PR TITLE
Add frame-based self mask with padding

### DIFF
--- a/src/mask/build_self_mask.m
+++ b/src/mask/build_self_mask.m
@@ -1,0 +1,45 @@
+function mask = build_self_mask(nFrames, hop, produced_labels, pad_pre, pad_post)
+% nframes:int, hop:seconds per frame
+% produced_labels [n×2] (s), pad_pre/post (s)
+% return logical [nframes×1] marking frames within padded produced windows.
+
+%% validate inputs
+if isempty(produced_labels)
+    produced_labels = zeros(0, 2);
+end
+validateattributes(nFrames, {'numeric'}, {'scalar', 'integer', '>=', 0}, mfilename, 'nFrames');
+validateattributes(hop, {'numeric'}, {'scalar', 'positive'}, mfilename, 'hop');
+validateattributes(produced_labels, {'numeric'}, {'2d', 'ncols', 2}, mfilename, 'produced_labels');
+validateattributes(pad_pre, {'numeric'}, {'scalar', '>=', 0}, mfilename, 'pad_pre');
+validateattributes(pad_post, {'numeric'}, {'scalar', '>=', 0}, mfilename, 'pad_post');
+if any(~isfinite(produced_labels(:)))
+    error('build_self_mask:InvalidLabels', 'Labels must be finite.');
+end
+if any(produced_labels(:, 2) < produced_labels(:, 1))
+    error('build_self_mask:InvalidOrder', 'Each label must satisfy onset <= offset.');
+end
+
+%% prep constants
+nFrames = double(nFrames);
+hop = double(hop);
+produced_labels = double(produced_labels);
+pad_pre = double(pad_pre);
+pad_post = double(pad_post);
+mask = false(nFrames, 1);
+if nFrames == 0 || isempty(produced_labels)
+    return;
+end
+
+%% build padded intervals and mark frames
+padded = [produced_labels(:, 1) - pad_pre, produced_labels(:, 2) + pad_post];
+padded = sortrows(padded, 1);
+frame_starts = (0:nFrames-1).' .* hop;
+frame_ends = frame_starts + hop;
+for idx = 1:size(padded, 1)
+    window_start = padded(idx, 1);
+    window_end = padded(idx, 2);
+    hits = (frame_starts < window_end) & (frame_ends > window_start);
+    mask = mask | hits;
+end
+mask = logical(mask);
+end

--- a/tests/mask/test_self_mask.m
+++ b/tests/mask/test_self_mask.m
@@ -1,0 +1,48 @@
+classdef test_self_mask < matlab.unittest.TestCase
+    %% setup paths
+    methods (TestClassSetup)
+        function add_paths(tc) %#ok<INUSD>
+            root_dir = fileparts(fileparts(fileparts(mfilename('fullpath'))));
+            addpath(fullfile(root_dir, 'src', 'mask'));
+            addpath(fullfile(root_dir, 'tests', 'fixtures'));
+        end
+    end
+
+    %% tests
+    methods (Test)
+        function self_mask_covers_self_and_spares_far(tc)
+            [x, fs, self_labels] = make_synth_colony_track();
+            hop = 0.01;
+            duration = numel(x) / fs;
+            nFrames = ceil(duration / hop);
+
+            pad_pre = 1.0;
+            pad_post = 0.5;
+            mask = build_self_mask(nFrames, hop, self_labels, pad_pre, pad_post);
+
+            tc.verifySize(mask, [nFrames, 1]);
+            tc.verifyClass(mask, 'logical');
+
+            frame_starts = (0:nFrames-1).' * hop;
+            frame_ends = frame_starts + hop;
+
+            for idx = 1:size(self_labels, 1)
+                coverage = (frame_starts < self_labels(idx, 2)) & (frame_ends > self_labels(idx, 1));
+                if any(coverage)
+                    tc.verifyTrue(all(mask(coverage)));
+                end
+            end
+
+            near_frames = false(nFrames, 1);
+            margin = 2.0;
+            for idx = 1:size(self_labels, 1)
+                expanded_start = self_labels(idx, 1) - margin;
+                expanded_end = self_labels(idx, 2) + margin;
+                near_frames = near_frames | ((frame_starts < expanded_end) & (frame_ends > expanded_start));
+            end
+            far_frames = ~near_frames;
+            tc.verifyTrue(any(far_frames));
+            tc.verifyFalse(any(mask(far_frames)));
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- implement a frame-based self mask that pads produced labels before marking frames
- validate inputs and return a logical column vector mask
- add a unit test that exercises padded coverage and ensures distant frames stay unmasked

## Testing
- not run (matlab unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cd97fcda1c832ba8da7054a3757b7b