### PR TITLE
Add preprocessing resample and bandpass

### DIFF
--- a/src/detect/bandpass_5to14k.m
+++ b/src/detect/bandpass_5to14k.m
@@ -1,0 +1,25 @@
+function y = bandpass_5to14k(x, fs)
+%% validate inputs
+validateattributes(x, {'numeric'}, {'nonempty'}, mfilename, 'x');
+if ndims(x) > 2
+    error('bandpass_5to14k:InvalidInput', 'x must be a vector or 2d matrix.');
+end
+validateattributes(fs, {'numeric'}, {'scalar', 'positive'}, mfilename, 'fs');
+fs = double(fs);
+nyquist = fs / 2;
+if nyquist <= 14000
+    error('bandpass_5to14k:NyquistTooLow', 'nyquist must exceed 14 kHz.');
+end
+
+%% filter waveform
+[b, a] = butter(4, [5000 14000] / nyquist, 'bandpass');
+was_row = isrow(x);
+if was_row
+    x = x.';
+end
+x = double(x);
+y = filtfilt(b, a, x);
+if was_row
+    y = y.';
+end
+end

--- a/src/detect/resample_if_needed.m
+++ b/src/detect/resample_if_needed.m
@@ -1,0 +1,29 @@
+function [y, fs_out] = resample_if_needed(x, fs_in, fs_target)
+%% validate inputs
+validateattributes(x, {'numeric'}, {'nonempty'}, mfilename, 'x');
+if ndims(x) > 2
+    error('resample_if_needed:InvalidInput', 'x must be a vector or 2d matrix.');
+end
+validateattributes(fs_in, {'numeric'}, {'scalar', 'positive'}, mfilename, 'fs_in');
+validateattributes(fs_target, {'numeric'}, {'scalar', 'positive'}, mfilename, 'fs_target');
+fs_in = double(fs_in);
+fs_target = double(fs_target);
+
+%% perform resampling
+if fs_in == fs_target
+    y = x;
+    fs_out = fs_in;
+    return;
+end
+
+was_row = isrow(x);
+if was_row
+    x = x.';
+end
+x = double(x);
+y = resample(x, fs_target, fs_in);
+if was_row
+    y = y.';
+end
+fs_out = fs_target;
+end

--- a/tests/detect/test_preprocess.m
+++ b/tests/detect/test_preprocess.m
@@ -1,0 +1,41 @@
+classdef test_preprocess < matlab.unittest.TestCase
+    %% setup paths
+    methods (TestClassSetup)
+        function add_source_to_path(tc) %#ok<INUSD>
+            root_dir = fileparts(fileparts(fileparts(mfilename('fullpath'))));
+            addpath(fullfile(root_dir, 'src', 'detect'));
+        end
+    end
+
+    %% tests
+    methods (Test)
+        function bandpass_targets_high_band(tc)
+            fs = 48000;
+            t = (0:fs-1).' / fs;
+            low = sin(2 * pi * 1000 * t);
+            high = sin(2 * pi * 7000 * t);
+            y_low = bandpass_5to14k(low, fs);
+            y_high = bandpass_5to14k(high, fs);
+            low_rms = sqrt(mean(y_low .^ 2));
+            high_rms = sqrt(mean(y_high .^ 2));
+            tc.verifyLessThan(low_rms, 1e-3);
+            tc.verifyGreaterThan(high_rms, 0.6);
+        end
+
+        function resample_matches_expected_length(tc)
+            fs_in = 48000;
+            fs_target = 24000;
+            duration = 0.75;
+            n = round(fs_in * duration);
+            t = (0:n-1).' / fs_in;
+            x = sin(2 * pi * 2500 * t);
+            [y, fs_out] = resample_if_needed(x, fs_in, fs_target);
+            tc.verifyEqual(fs_out, fs_target);
+            expected_length = round(n * fs_target / fs_in);
+            tc.verifyLessThanOrEqual(abs(length(y) - expected_length), 1);
+            [y_same, fs_same] = resample_if_needed(x, fs_in, fs_in);
+            tc.verifyEqual(y_same, x);
+            tc.verifyEqual(fs_same, fs_in);
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- add a resampling helper that reuses the input sample rate when already matched
- introduce a 5–14 kHz zero-phase Butterworth band-pass filter with Nyquist validation
- cover the new preprocessing utilities with unit tests for filtering and resampling behavior

## Testing
- matlab -batch "cd('tests'); runtests('tests')" *(fails: command not found)*
- octave --eval "disp('running tests')" *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68cd99cb83b0832bb96ce9d05e834379