### PR TITLE
Add frame-level spectrogram and feature extraction

### DIFF
--- a/src/detect/feat_energy_entropy_flux.m
+++ b/src/detect/feat_energy_entropy_flux.m
@@ -1,0 +1,54 @@
+function feats = feat_energy_entropy_flux(S, f, bands)
+% feat_energy_entropy_flux computes energy, entropy, and spectral flux features per frame.
+
+narginchk(3, 3);
+
+%% validate inputs
+validateattributes(S, {'numeric'}, {'2d', 'nonempty', 'real', '>=', 0}, mfilename, 'S');
+validateattributes(f, {'numeric'}, {'vector', 'numel', size(S, 1)}, mfilename, 'f');
+validateattributes(bands, {'struct'}, {'scalar'}, mfilename, 'bands');
+if ~isfield(bands, 'energy') || ~isfield(bands, 'entropy')
+    error('feat_energy_entropy_flux:MissingBand', 'bands must include energy and entropy fields.');
+end
+validateattributes(bands.energy, {'numeric'}, {'vector', 'numel', 2}, mfilename, 'bands.energy');
+validateattributes(bands.entropy, {'numeric'}, {'vector', 'numel', 2}, mfilename, 'bands.entropy');
+S = double(S);
+f = double(f(:));
+
+%% compute energy feature
+energy_mask = f >= bands.energy(1) & f <= bands.energy(2);
+if any(energy_mask)
+    energy_vals = sum(S(energy_mask, :), 1).';
+else
+    energy_vals = zeros(size(S, 2), 1);
+end
+
+%% compute entropy feature
+entropy_mask = f >= bands.entropy(1) & f <= bands.entropy(2);
+entropy_vals = zeros(size(S, 2), 1);
+if any(entropy_mask)
+    Sb = S(entropy_mask, :);
+    total = sum(Sb, 1);
+    total_safe = total;
+    total_safe(total_safe == 0) = 1;
+    p = bsxfun(@rdivide, Sb, total_safe);
+    entropy_vals = -sum(p .* log2(p + eps), 1).';
+    entropy_vals(total == 0) = 0;
+end
+
+%% compute flux feature
+flux_mask = energy_mask;
+flux_vals = zeros(size(S, 2), 1);
+if any(flux_mask)
+    Sb = S(flux_mask, :);
+    if size(Sb, 2) > 1
+        diffs = Sb(:, 2:end) - Sb(:, 1:end-1);
+        diffs(diffs < 0) = 0;
+        flux_vals(2:end) = sum(diffs, 1).';
+    end
+end
+
+feats.energy = energy_vals;
+feats.entropy = entropy_vals;
+feats.flux = flux_vals;
+end

--- a/src/detect/frame_spectrogram.m
+++ b/src/detect/frame_spectrogram.m
@@ -1,0 +1,37 @@
+function [S, f, t] = frame_spectrogram(x, fs, win, hop)
+% frame_spectrogram returns power spectrogram (linear), frequency, and time vectors.
+
+narginchk(4, 4);
+
+%% validate inputs
+validateattributes(x, {'numeric'}, {'vector', 'nonempty'}, mfilename, 'x');
+validateattributes(fs, {'numeric'}, {'scalar', 'positive'}, mfilename, 'fs');
+validateattributes(hop, {'numeric'}, {'scalar', 'integer', '>=', 1}, mfilename, 'hop');
+fs = double(fs);
+hop = double(hop);
+x = double(x(:));
+if isscalar(win)
+    validateattributes(win, {'numeric'}, {'scalar', 'integer', '>=', 1}, mfilename, 'win');
+    win_length = double(win);
+    if win_length == 1
+        win = 1;
+    else
+        n = (0:win_length-1).';
+        win = 0.5 - 0.5 * cos(2 * pi * n / (win_length - 1));
+    end
+else
+    validateattributes(win, {'numeric'}, {'vector', 'nonempty'}, mfilename, 'win');
+    win = double(win(:));
+    win_length = numel(win);
+end
+if hop >= win_length
+    error('frame_spectrogram:InvalidHop', 'hop must be smaller than the window length.');
+end
+
+%% compute spectrogram
+noverlap = win_length - hop;
+[stft, f, t] = spectrogram(x, win, noverlap, [], fs);
+S = abs(stft).^2;
+f = f(:);
+t = t(:);
+end

--- a/tests/detect/test_features_basic.m
+++ b/tests/detect/test_features_basic.m
@@ -1,0 +1,71 @@
+classdef test_features_basic < matlab.unittest.TestCase
+    %% setup paths
+    methods (TestClassSetup)
+        function add_source_to_path(tc) %#ok<INUSD>
+            root_dir = fileparts(fileparts(fileparts(mfilename('fullpath'))));
+            addpath(fullfile(root_dir, 'src', 'detect'));
+        end
+    end
+
+    %% tests
+    methods (Test)
+        function energy_rises_with_tone(tc)
+            data = test_features_basic.synth_fixture();
+            tone_energy = mean(data.feats.energy(data.tone_mask));
+            noise_energy = mean(data.feats.energy(~data.tone_mask));
+            tc.verifyGreaterThan(tone_energy, 5 * noise_energy);
+        end
+
+        function entropy_drops_with_tone(tc)
+            data = test_features_basic.synth_fixture();
+            tone_entropy = mean(data.feats.entropy(data.tone_mask));
+            noise_entropy = mean(data.feats.entropy(~data.tone_mask));
+            tc.verifyLessThan(tone_entropy, noise_entropy);
+        end
+
+        function flux_spikes_at_onset(tc)
+            data = test_features_basic.synth_fixture();
+            flux = data.feats.flux;
+            onset_idx = find(data.tone_mask, 1);
+            pre_noise_idx = 1:max(onset_idx - 1, 1);
+            onset_window = max(1, onset_idx - 1):min(length(flux), onset_idx + 1);
+            onset_peak = max(flux(onset_window));
+            baseline = max(flux(pre_noise_idx));
+            tc.verifyGreaterThan(onset_peak, 5 * baseline + 1e-9);
+            tc.verifyGreaterThan(onset_peak, 1e-6);
+        end
+    end
+
+    methods (Static, Access = private)
+        function data = synth_fixture()
+            rng(42);
+            fs = 48000;
+            noise_duration = 0.5;
+            tone_duration = 0.5;
+            noise = 0.01 * randn(round(fs * noise_duration), 1);
+            t_tone = (0:round(fs * tone_duration) - 1).' / fs;
+            tone = 0.2 * sin(2 * pi * 7000 * t_tone);
+            tone = tone + 0.01 * randn(size(tone));
+            x = [noise; tone];
+            win_length = 1024;
+            hop = 256;
+            [S, f, t] = frame_spectrogram(x, fs, win_length, hop);
+            tone_start = numel(noise) / fs;
+            frame_centers = ((0:size(S, 2) - 1) * hop + win_length / 2) / fs;
+            tone_mask = frame_centers >= tone_start;
+            if ~any(tone_mask)
+                tone_mask(end) = true;
+            end
+            if ~any(~tone_mask)
+                tone_mask(1) = false;
+            end
+            tone_mask = tone_mask(:);
+            bands.energy = [5000 14000];
+            bands.entropy = [6000 10000];
+            feats = feat_energy_entropy_flux(S, f, bands);
+            data.feats = feats;
+            data.t = t;
+            data.tone_mask = tone_mask;
+        end
+    end
+end


### PR DESCRIPTION
## Summary
- implement a frame_spectrogram helper that returns a linear power spectrogram with frequency and time vectors
- compute frame-level energy, entropy, and spectral flux features with configurable bands
- add unit tests that validate the feature behavior on a synthetic tone-plus-noise fixture

## Testing
- matlab -batch "cd('tests'); results = runtests('detect'); disp(results)" *(fails: matlab not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cd9c256c14832ba58da8d1ae8cc9e1